### PR TITLE
Add the `!==` operator in mIRC-msl.sublime-syntax

### DIFF
--- a/mIRC-msl.sublime-syntax
+++ b/mIRC-msl.sublime-syntax
@@ -222,7 +222,7 @@ contexts:
 
   keywords2:
     # based on https://en.wikichip.org/wiki/mirc/operators
-    - match: '(?i)(\||===|==|!=|>=|<=|<|>|\&|\$\+|\$iif)'
+    - match: '(?i)(\||===|==|!==|!=|>=|<=|<|>|\&|\$\+|\$iif)'
       scope: keyword.operator.msl
 
   identifiers:


### PR DESCRIPTION
Thanks a lot for your great work, @eneerge !

With this PR I suggest adding the `!==` operator.